### PR TITLE
Fix index error

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -179,7 +179,7 @@ resource "aws_route53_record" "web_cert_validation" {
   name    = tolist(aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_name
   type    = tolist(aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_type
   zone_id = module.dns.public_zone_id
-  records = tolist([aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 
@@ -204,7 +204,7 @@ resource "aws_route53_record" "streaming_cert_validation" {
   name    = tolist(aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_name
   type    = tolist(aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_type
   zone_id = module.dns.public_zone_id
-  records = tolist([aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/alb.tf
+++ b/alb.tf
@@ -176,10 +176,10 @@ resource "aws_acm_certificate" "web_cert" {
 }
 
 resource "aws_route53_record" "web_cert_validation" {
-  name    = aws_acm_certificate.web_cert.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.web_cert.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_type
   zone_id = module.dns.public_zone_id
-  records = [aws_acm_certificate.web_cert.domain_validation_options[0].resource_record_value]
+  records = tolist([aws_acm_certificate.web_cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 
@@ -201,10 +201,10 @@ resource "aws_acm_certificate" "streaming_cert" {
 }
 
 resource "aws_route53_record" "streaming_cert_validation" {
-  name    = aws_acm_certificate.streaming_cert.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.streaming_cert.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_type
   zone_id = module.dns.public_zone_id
-  records = [aws_acm_certificate.streaming_cert.domain_validation_options[0].resource_record_value]
+  records = tolist([aws_acm_certificate.streaming_cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 


### PR DESCRIPTION
This commit will fix an error with the newer v3.0 AWS provider.  aws_acm_certificate.web_cert.domain_validation_options now returns a set instead of a list, this commit will force the return back to a list