### PR TITLE
Change host header to hash

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -100,8 +100,9 @@ resource "aws_lb_listener_rule" "alb_web_listener_rule" {
   }
 
   condition {
-    field  = "host-header"
-    values = [aws_route53_record.alb.fqdn]
+    host_header {
+      values = [aws_route53_record.alb.fqdn]
+    }
   }
 }
 
@@ -137,8 +138,9 @@ resource "aws_lb_listener_rule" "alb_streaming_listener_rule" {
   }
 
   condition {
-    field  = "host-header"
-    values = [aws_route53_record.alb_streaming.fqdn]
+      host_header {
+        values = [aws_route53_record.alb_streaming.fqdn]
+    }
   }
 }
 


### PR DESCRIPTION
@phuongdh This change is necessary to work with aws provider > 3.0, I do believe this change will break older provider versions.