### PR TITLE
Add variable for compose instance size

### DIFF
--- a/compose.tf
+++ b/compose.tf
@@ -168,7 +168,7 @@ resource "aws_instance" "compose" {
   )
 
   root_block_device {
-    volume_size = "50"
+    volume_size = var.compose_volume_size
     volume_type = "standard"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "compose_instance_type" {
   default = "t3.large"
 }
 
+variable "compose_volume_size" {
+  type = number
+  default = 75
+  description = "The root volume size, in gigabytes, of the ec2 that runs the avalon docker containers"
+}
+
 variable "db_avalon_username" {
   default = "dbavalon"
 }


### PR DESCRIPTION
Small PR that will add new variable for compose instance size. Default has been set to 75 gigs.