### PR TITLE
Give users option of SSL on fedora database connection

### DIFF
--- a/compose.tf
+++ b/compose.tf
@@ -199,7 +199,7 @@ resource "null_resource" "install_docker_on_compose" {
     }
 
     content = <<EOF
-FEDORA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql-s3/repository${var.fedora_ssl ? "-ssl" : ""}.json -Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
+FEDORA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql-s3/repository${var.fcrepo_db_ssl ? "-ssl" : ""}.json -Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
 FEDORA_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/fedora.log
 
 SOLR_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/solr.log

--- a/compose.tf
+++ b/compose.tf
@@ -199,7 +199,7 @@ resource "null_resource" "install_docker_on_compose" {
     }
 
     content = <<EOF
-FEDORA_OPTIONS=-Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
+FEDORA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql-s3/repository${var.fedora_ssl ? "-ssl" : ""}.json -Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
 FEDORA_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/fedora.log
 
 SOLR_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/solr.log

--- a/compose.tf
+++ b/compose.tf
@@ -203,7 +203,7 @@ FEDORA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresq
 FEDORA_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/fedora.log
 
 SOLR_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/solr.log
-
+S3_HELPER_LOGROUP==${aws_cloudwatch_log_group.compose_log_group.name}/s3-helper.log
 HLS_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/hls.log
 AVALON_STREAMING_BUCKET=${aws_s3_bucket.this_derivatives.id}
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,12 +71,6 @@ variable "environment" {
   type = string
 }
 
-variable "fedora_ssl" {
-  type = bool
-  default = false
-  description = "Forces the fedora database connection to use ssl."
-}
-
 variable "fcrepo_binary_bucket_username" {
   type = string
 }
@@ -87,6 +81,12 @@ variable "fcrepo_binary_bucket_access_key" {
 
 variable "fcrepo_binary_bucket_secret_key" {
   type = string
+}
+
+variable "fcrepo_db_ssl" {
+  type = bool
+  default = false
+  description = "Forces SSL on the fedora database connection"
 }
 
 variable "hosted_zone_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "environment" {
   type = string
 }
 
+variable "fedora_ssl" {
+  type = bool
+  default = false
+  description = "Forces the fedora database connection to use ssl."
+}
+
 variable "fcrepo_binary_bucket_username" {
   type = string
 }


### PR DESCRIPTION
PR enables possibility of fedora SSL encryption, it's logic has been tested on the emorylibraries avalon-terraform fork.

NOTE1: Do not merge this until the emory branch of avalon-docker has been merged into aws_min

NOTE2: The default for the new variable **fedora_ssl** has been set to false, so unencrypted fedora database connection is still the overall default behavior.