### PR TITLE
Dependency fix & EC2 DNS record

### DIFF
--- a/compose.tf
+++ b/compose.tf
@@ -241,6 +241,14 @@ resource "aws_instance" "compose" {
   }
 }
 
+resource "aws_route53_record" "ec2_hostname" {
+  zone_id = module.dns.public_zone_id
+  name    = local.ec2_hostname
+  type    = "A"
+  ttl     = 300
+  records = [aws_instance.compose.public_ip]
+}
+
 resource "null_resource" "install_docker_on_compose" {
   triggers = {
     host = aws_instance.compose.id

--- a/db-avalon.tf
+++ b/db-avalon.tf
@@ -4,6 +4,7 @@ module "db_avalon_password" {
 
 module "db_avalon" {
   source  = "terraform-aws-modules/rds/aws"
+  version = "~> 5.0"
 
   identifier = "${local.namespace}-avalon-db"
 

--- a/db-fcrepo.tf
+++ b/db-fcrepo.tf
@@ -4,6 +4,7 @@ module "db_fcrepo_password" {
 
 module "db_fcrepo" {
   source  = "terraform-aws-modules/rds/aws"
+  version = "~> 5.0"
 
   identifier = "${local.namespace}-fcrepo-db"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -126,6 +126,10 @@ output "private_zone_id" {
   value = module.dns.private_zone_id
 }
 
+output "public_ec2_hostname" {
+  value = aws_route53_record.ec2_hostname.fqdn
+}
+
 output "public_ip" {
   value = aws_instance.compose.public_ip
 }

--- a/variables.tf
+++ b/variables.tf
@@ -211,6 +211,7 @@ locals {
   namespace         = "${var.stack_name}-${var.environment}"
   public_zone_name  = "${var.zone_prefix}${var.environment}.${var.hosted_zone_name}"
   private_zone_name = "vpc.${var.zone_prefix}${var.environment}.${var.hosted_zone_name}"
+  ec2_hostname      = "ec2.${local.public_zone_name}"
 
   common_tags = merge(
     var.tags,

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
 
   name = "${local.namespace}-vpc"
 
@@ -19,6 +20,7 @@ module "vpc" {
 
 module "endpoints" {
   source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 3.0"
 
   vpc_id             = module.vpc.vpc_id
   security_group_ids = [module.vpc.default_security_group_id]


### PR DESCRIPTION
The RDS and VPC modules were not locked to a specific version and newer versions were causing failures to new terraform deployments. This change sets the RDS module to 5.x and the VPC module to 3.x.

And for convenience in connecting to the EC2 instance via SSH, a new route 53 record is added which points to the public EC2 IP address. Basically ec2.{public_zone_name}. This value is also added the out TF outputs.

Let me know if you have and questions or would like to see something changed!