### PR TITLE
Add avalon_commit var to set git hash for build

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -43,11 +43,18 @@ variable "avalon_admin" {
 }
 
 variable "avalon_repo" {
+  description = "The repository to pull when building the Avalon image"
   default = "https://github.com/avalonmediasystem/avalon"
 }
 
 variable "avalon_branch" {
+  description = "The branch to use when building the Avalon image"
   default = "demo"
+}
+
+variable "avalon_commit" {
+  description = "The full commit hash to use when building the Avalon image (empty defaults to most recent for the avalon_branch)"
+  default = ""
 }
 
 variable "bib_retriever_protocol" {


### PR DESCRIPTION
Create an optional avalon_commit TF var to allow manually setting which git commit to base the CodeBuild off of. If unset (the default), will operate as previously, pulling the commit hash from the branch name.

Includes a rename of internal var from AVALON_REV to AVALON_COMMIT to consistency between it and the var.