### PR TITLE
Setup CORS headers for supplemental files bucket

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -43,6 +43,17 @@ resource "aws_s3_bucket" "this_supplemental_files" {
   force_destroy = "false"
 }
 
+resource "aws_s3_bucket_cors_configuration" "this_supplemental_files" {
+  bucket = aws_s3_bucket.this_supplemental_files.id
+
+  cors_rule {
+    allowed_origins = ["*"]
+    allowed_methods = ["GET"]
+    max_age_seconds = "3000"
+    allowed_headers = ["Authorization", "Access-Control-Allow-Origin"]
+  }
+}
+
 data "aws_iam_policy_document" "this_bucket_access" {
   statement {
     effect    = "Allow"


### PR DESCRIPTION
ActiveStorage will return a signed url for download of supplemental files from S3 which works for direct access, but when fetching for use in IIIF viewsers like ramp the browser rejects the download due to missing CORS headers.  This PR sets up the CORS configuration for the supplemental files bucket to mirror the configuration the derivatives bucket is already using.  With this configuration in place, ramp is able to successfully fetch transcritps.